### PR TITLE
Update force_field_mixing_rules.def

### DIFF
--- a/ForceFields/UFF/force_field_mixing_rules.def
+++ b/ForceFields/UFF/force_field_mixing_rules.def
@@ -61,7 +61,7 @@ Nd_            lennard-jones     5.03220  3.18496      //
 Pm_            lennard-jones     4.52898  3.16002      // 
 Sm_            lennard-jones     4.02576  3.13596      // 
 Eu_            lennard-jones     4.02576  3.11191      // 
-Ge_            lennard-jones     4.52898  3.00055      // 
+Gd_            lennard-jones     4.52898  3.00055      // 
 Tb_            lennard-jones     3.52254  3.07449      // 
 Dy_            lennard-jones     3.52254  3.05400      // 
 Ho_            lennard-jones     3.52254  3.03707      // 


### PR DESCRIPTION
Hello,

In the files of the UFF LJ parameters the line 64 should read Gd_ instead of Ge_