### PR TITLE
Add parameters for adsorbed molecules

### DIFF
--- a/ForceFields/DREIDING/force_field_mixing_rules.def
+++ b/ForceFields/DREIDING/force_field_mixing_rules.def
@@ -3,7 +3,7 @@ shifted
 # general rule tailcorrections
 no
 # number of defined interactions
-49
+51
 # type,        interaction,  epsilon [K],  sigma [A] IMPORTANT: define shortest matches first, so that more specific ones overwrites these
 H_             lennard-jones   7.648938   2.84642      // DREIDING  S.L. Mayo et al., J. Phys. Chem. 1990, 94, 8897-8909.
 B_             lennard-jones    47.8058   3.58141      // DREIDING
@@ -54,5 +54,7 @@ Lw_T5          none                                    // idem
 Hw_T5          none                                    // idem
 S_so2          lennard-jones    73.8       3.39        // J. Phys. Chem. B 2011, 115, 17, 4949–4954
 O_so2          lennard-jones    79.0       3.05        // J. Phys. Chem. B 2011, 115, 17, 4949–4954 
+Ow_spce        lennard-jones    78.15      3.166       // J. Phys. Chem. A 2001, 105, 9954-9960
+Hw_spce        none
 # general mixing rule for Lennard-Jones
 Lorentz-Berthelot

--- a/ForceFields/DREIDING/force_field_mixing_rules.def
+++ b/ForceFields/DREIDING/force_field_mixing_rules.def
@@ -35,8 +35,8 @@ O_o2           lennard-jones    53.0230   3.04500      // idem
 O_com          none                                    // idem
 Ar             lennard-jones   124.0700   3.38000      // idem
 CH4            lennard-jones   148.0000   3.73000      // M.G. Martin, and J.I. Siepmann, J. Phys. Chem. B 102, 2569-2577 (1998)
-H_h2           none                                    // Q. Yang., and C. Zhong, J. Phys. Chem. B 2005, 109, 24, 11862–11864
-H_com          lennard-jones    10.0000   2.72000      //
+H_h2           none                                    // Paula García-Holley et al., ACS Energy Lett. 2018, 3, 3, 748–754
+H_com          feynman-hibbs-lennard-jones    36.7000   2.95800    1.008  //
 C_co           lennard-jones    16.1410   3.63600      // A. Martin-Calvo et al. , J. Phys. Chem. C. 2012, 116, 6655.
 CO_com         none                                    // idem
 O_co           lennard-jones    98.0140   2.97900      // idem

--- a/ForceFields/DREIDING/pseudo_atoms.def
+++ b/ForceFields/DREIDING/pseudo_atoms.def
@@ -1,5 +1,5 @@
 #number of pseudo atoms
-49
+51
 #type      print   as    chem  oxidation   mass        charge   polarization B-factor radii  connectivity anisotropic anisotropic-type   tinker-type
 H          yes     H     H     0           1.00794    0.0      0.0          1.0      0.250  0            0           relative           0
 B          yes     B     B     0          10.81100    0.0      0.0          1.0      0.850  0            0           relative           0
@@ -49,4 +49,6 @@ Ow_T4ew    yes     O     O     0          15.99940    0.000    0.0          1.0 
 Hw_T4ew    yes     H     H     0           1.00794    0.5242   0.0          1.0      1.00   0            0           relative           0
 M_T4ew     no      L     -     0           0.00000   -1.04844  0.0          1.0      1.00   0            0           relative           0
 O_so2      yes     O     O     0          15.99940   -0.295    0.0          1.0      0.730  0            0           relative           0
-S_so2      yes     S     S     0          32.06500    0.59     0.0 
+S_so2      yes     S     S     0          32.06500    0.59     0.0          1.0      0.730  0            0           relative           0
+Ow_spce    yes     O     O     0          15.99940   -0.8476   0.0          1.0      1.00   0            0           relative           0
+Hw_spce    yes     H     H     0           1.00794    0.4238   0.0          1.0      1.00   0            0           relative           0

--- a/ForceFields/MoleculeDefinitions/H2.def
+++ b/ForceFields/MoleculeDefinitions/H2.def
@@ -1,0 +1,23 @@
+# critical constants: Temperature [T], Pressure [Pa], and Acentric factor [-]
+33.19
+1313000.0
+-0.216
+#Number Of Atoms
+3
+# Number of groups
+1
+# H2-group
+rigid
+# number of atoms
+3
+# atomic positions
+0 H_h2     0.0           0.0           0.3714
+1 H2_com   0.0           0.0           0.0
+2 H_h2     0.0           0.0          -0.3714
+# Chiral centers Bond  BondDipoles Bend  UrayBradley InvBend  Torsion Imp. Torsion Bond/Bond Stretch/Bend Bend/Bend Stretch/Torsion Bend/Torsion IntraVDW IntraCoulomb
+               0    2            0    0            0       0        0            0         0            0         0               0            0        0            0
+# Bond stretch: atom n1-n2, type, parameters
+0 1 RIGID_BOND
+1 2 RIGID_BOND
+# Number of config moves
+0

--- a/ForceFields/MoleculeDefinitions/SPC-E.def
+++ b/ForceFields/MoleculeDefinitions/SPC-E.def
@@ -1,0 +1,23 @@
+# critical constants: Temperature [T], Pressure [Pa], and Acentric factor [-]
+623.0        // W. C. Volker, The Journal of Chemical Physics 146.5 (2017)
+13400000     // W. C. Volker, The Journal of Chemical Physics 146.5 (2017)
+0.580722     // W. C. Volker, The Journal of Chemical Physics 146.5 (2017)
+# total number Of atoms
+3
+# number of groups
+1
+# water-group
+rigid
+# number of atoms
+3
+# atomic positions
+0 Ow_spce                  0.00000000    0.00000000    0.00000000
+1 Hw_spce                  0.65806264   -0.75296318    0.00000000
+2 Hw_spce                  0.49056485    0.87140469    0.00000000
+# Chiral centers Bond  BondDipoles Bend  UrayBradley InvBend  Torsion Imp. Torsion Bond/Bond Stretch/Bend Bend/Bend Stretch/Torsion Bend/Torsion IntraVDW IntraCoulomb
+               0    2            0    0            0       0        0            0         0            0         0               0            0        0            0
+# Bond stretch: atom n1-n2, type, parameters
+0 1 RIGID_BOND
+0 2 RIGID_BOND
+# Number of config moves
+0

--- a/ForceFields/UFF/force_field_mixing_rules.def
+++ b/ForceFields/UFF/force_field_mixing_rules.def
@@ -3,7 +3,7 @@ shifted
 # general rule tailcorrections
 no
 # number of defined interactions
-122
+124
 # type,        interaction,  epsilon [K],  sigma [A] IMPORTANT: define shortest matches first, so that more specific ones overwrites these
 C_             lennard-jones    52.83806  3.43085      // UFF A.K. Rappé et al., J. Am. Chem. Soc. 1992, 114, 10024-10035. 
 O_             lennard-jones    30.19317  3.11815      //
@@ -127,5 +127,7 @@ Lw_T5          none                                    // idem
 Hw_T5          none                                    // idem
 S_so2          lennard-jones    73.8       3.39        // J. Phys. Chem. B 2011, 115, 17, 4949–4954
 O_so2          lennard-jones    79.0       3.05        // J. Phys. Chem. B 2011, 115, 17, 4949–4954 
+Ow_spce        lennard-jones    78.15      3.166       // J. Phys. Chem. A 2001, 105, 9954-9960
+Hw_spce        none
 # general mixing rule for Lennard-Jones
 Lorentz-Berthelot

--- a/ForceFields/UFF/force_field_mixing_rules.def
+++ b/ForceFields/UFF/force_field_mixing_rules.def
@@ -108,8 +108,8 @@ O_o2           lennard-jones    53.0230   3.04500      // idem
 O_com          none                                    // idem
 Ar             lennard-jones   124.0700   3.38000      // idem
 CH4            lennard-jones   148.0000   3.73000      // M.G. Martin, and J.I. Siepmann, J. Phys. Chem. B 102, 2569-2577 (1998)
-H_h2           none                                    // Q. Yang., and C. Zhong, J. Phys. Chem. B 2005, 109, 24, 11862–11864
-H_com          lennard-jones    10.0000   2.72000      //
+H_h2           none                                    // Paula García-Holley et al., ACS Energy Lett. 2018, 3, 3, 748–754
+H_com          feynman-hibbs-lennard-jones    36.7000   2.95800    1.008  //
 C_co           lennard-jones    16.1410   3.63600      // A. Martin-Calvo et al. , J. Phys. Chem. C. 2012, 116, 6655.
 CO_com         none                                    // idem
 O_co           lennard-jones    98.0140   2.97900      // idem

--- a/ForceFields/UFF/pseudo_atoms.def
+++ b/ForceFields/UFF/pseudo_atoms.def
@@ -1,5 +1,5 @@
 #number of pseudo atoms
-122
+124
 #type      print   as    chem  oxidation   mass        charge   polarization B-factor radii  connectivity anisotropic anisotropic-type   tinker-type
 C          yes      C     C     0         12.01070    0.0      0.0          1.0      0.770  0            0           relative           0
 O          yes      O     O     0         15.99940    0.0      0.0          1.0      0.730  0            0           relative           0
@@ -123,3 +123,5 @@ Hw_T4ew    yes     H     H     0           1.00794    0.5242   0.0          1.0 
 M_T4ew     no      L     -     0           0.00000   -1.04844  0.0          1.0      1.00   0            0           relative           0
 O_so2      yes     O     O     0          15.99940   -0.295    0.0          1.0      0.730  0            0           relative           0
 S_so2      yes     S     S     0          32.06500    0.59     0.0          1.0      1.020  0            0           relative           0
+Ow_spce    yes     O     O     0          15.99940   -0.8476   0.0          1.0      1.00   0            0           relative           0
+Hw_spce    yes     H     H     0           1.00794    0.4238   0.0          1.0      1.00   0            0           relative           0


### PR DESCRIPTION
This PR updates the Force Field parameters to fix existing errors (as reported in #10) and includes new parameters.

## Fixed errors

- Some bond assignments on the molecular definitions.

## New parameters

### The SPC/E water molecule was added to both UFF and DREIDING.
The Critical parameters were taken from 
> WEISS, Volker C. Corresponding-states behavior of SPC/E-based modified (bent and hybrid) water models. The Journal of Chemical Physics, 2017, vol. 146, no 5.

The $\omega$ was calculated manually using the expression

$$
\omega = -log_{10}(p_r^{sat}) - 1, \quad T_r =0.7
$$

where $p_r^{sat} = p^{sat}/p^c$ with the saturation pressure calculated at T = 436.1 K, corresponding to $T_r = T/ T^c = 0.7$ 

The $p^{sat}$ was calculated using the Antoine equation

$$
ln(p^{sat}) = A + \frac{B}{T+C}
$$

With the parameters `A = 12.9162887916027`, `B = 4839.969763899371`, `C = -20.943781373080583` obtained from the fit of the Antoine equation on the data presented in Table S1 from the paper.

### The parameter for the H<sub>2</sub> molecule was added to both UFF and DREIDING

The LJ parameters were taken from
> GARCÍA-HOLLEY, Paula et al. Benchmark study of hydrogen storage in metal–organic frameworks under temperature and pressure swing conditions. ACS Energy Letters, v. 3, n. 3, p. 748-754, 2018.

The critical parameters were taken from experimental data presented in Appendix A of
> DE NEVERS, Noel. Physical and chemical equilibrium for chemical engineers. John Wiley & Sons, 2012.

Ideally, the critical parameters should be determined for the specific parametrization of the molecule and not taken from experimental data. However, there is no simulation data that allows the determination of critical parameters.

For the H<sub>2</sub> potential, the quantum correction proposed by Feynman-Hibbs is used, making the potential of interaction be calculated as 

$$
V_{FH}(r_{ij}) = {4\varepsilon_{ij}\left[\left(\frac{\sigma_{ij}}{r_{ij}}\right)^{12}-\left(\frac{\sigma_{ij}}{r_{ij}}\right)^{6}\right] + \frac{\hbar^2}{24 \mu_{ij} k_B T}*4\varepsilon_{ij}\left[ 132 \left( \frac{\sigma_{ij}}{r_{ij}}\right)^{12} - 30 \left( \frac{\sigma_{ij}}{r_{ij}}\right)^{6} \right]\frac{1}{r^2}}
$$

where $\mu_{ij}$ is the reduced mass in unified atomic mass units.

